### PR TITLE
ci: publish Nix Docker image to GHCR

### DIFF
--- a/.github/scripts/push-image.sh
+++ b/.github/scripts/push-image.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly image=$1
+readonly log=$2
+readonly transient_pattern='429|5[0-9]{2}|timeout|timed out|connection reset|unexpected EOF|temporar|service unavailable'
+
+for delay in 0 10 20; do
+  sleep "$delay"
+  if docker push "$image" 2>&1 | tee "$log"; then
+    exit 0
+  fi
+  if ! grep -Eqi "$transient_pattern" "$log"; then
+    echo "::error::Non-transient GHCR push failure; not retrying"
+    exit 1
+  fi
+done
+
+echo "::error::GHCR push failed after three transient attempts"
+exit 1

--- a/.github/scripts/push-image.sh
+++ b/.github/scripts/push-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 readonly image=$1
 readonly log=$2
-readonly transient_pattern='429|5[0-9]{2}|timeout|timed out|connection reset|unexpected EOF|temporar|service unavailable'
+readonly transient_pattern='HTTP status: (429|5[0-9]{2})|unexpected status.* (429|5[0-9]{2})|toomanyrequests|timeout|timed out|connection reset|unexpected EOF|temporar|service unavailable|internal server error|bad gateway'
 
 for delay in 0 10 20; do
   sleep "$delay"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -33,7 +33,11 @@ jobs:
       id-token: write
     env:
       IMAGE_NAME: ghcr.io/formosa-gpgpu/formosa
+      XDG_CACHE_HOME: /tmp/formosa-xdg-cache
     steps:
+      - name: Report initial disk usage
+        run: df -h /
+
       - name: Require main
         if: github.ref != 'refs/heads/main'
         run: |
@@ -73,7 +77,7 @@ jobs:
           attic login formosa "$ATTIC_SERVER" "$ATTIC_TOKEN" >/dev/null
           attic use "formosa:$ATTIC_CACHE" >/dev/null
 
-      - name: Report initial disk usage
+      - name: Report disk usage after setup
         run: df -h / /nix
 
       - name: Build image archive
@@ -82,6 +86,7 @@ jobs:
             --print-build-logs \
             --option download-attempts 3
           test -s result
+          df -h / /nix
 
       - name: Preserve archive and reclaim Nix store
         id: archive
@@ -90,6 +95,8 @@ jobs:
           archive="$RUNNER_TEMP/formosa-docker-env.tar.gz"
           cp --dereference result "$archive"
           rm result
+          nix profile remove attic-client
+          rm -rf -- "$XDG_CACHE_HOME/nix"
           nix store gc
           test -s "$archive"
           available_kib=$(df --output=avail / | tail -n 1)
@@ -138,6 +145,12 @@ jobs:
             if docker push "$image" 2>&1 | tee "$log"; then
               break
             fi
+            if ! grep -Eqi \
+              '429|5[0-9]{2}|timeout|timed out|connection reset|unexpected EOF|temporar|service unavailable' \
+              "$log"; then
+              echo "::error::Non-transient GHCR push failure; not retrying"
+              exit 1
+            fi
           done
           digest=$(sed -nE \
             's/.*digest: (sha256:[0-9a-f]{64}).*/\1/p' "$log" | tail -n 1)
@@ -157,11 +170,18 @@ jobs:
         run: |
           set -euo pipefail
           image="$IMAGE_NAME:latest"
+          log="$RUNNER_TEMP/docker-push-latest.log"
           docker tag "$IMAGE_ID" "$image"
           for delay in 0 10 20; do
             sleep "$delay"
-            if docker push "$image"; then
+            if docker push "$image" 2>&1 | tee "$log"; then
               exit 0
+            fi
+            if ! grep -Eqi \
+              '429|5[0-9]{2}|timeout|timed out|connection reset|unexpected EOF|temporar|service unavailable' \
+              "$log"; then
+              echo "::error::Non-transient GHCR push failure; not retrying"
+              exit 1
             fi
           done
           exit 1

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,6 +1,10 @@
 name: Publish Docker image
 
 on:
+  pull_request:
+    paths:
+      - .github/scripts/push-image.sh
+      - .github/workflows/publish-docker.yml
   push:
     branches: [main]
     paths:
@@ -23,8 +27,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate:
+    name: Validate workflow
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          enable_kvm: false
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate workflow and helper
+        run: |
+          nix shell --inputs-from . \
+            nixpkgs#actionlint \
+            nixpkgs#shellcheck \
+            --command bash -euo pipefail -c '
+              actionlint -shellcheck shellcheck .github/workflows/publish-docker.yml
+              shellcheck .github/scripts/push-image.sh
+            '
+
   publish:
     name: Build and publish
+    if: github.event_name != 'pull_request'
     runs-on: ${{ vars.DOCKER_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 360
     permissions:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -192,6 +192,7 @@ jobs:
           subject-name: ${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+          create-storage-record: false
 
       - name: Update latest tag
         env:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -14,6 +14,7 @@ on:
       - "hal/**"
       - "libcomm/**"
       - third-party/FreeRTOS-Kernel.cmake
+      - .github/scripts/push-image.sh
       - .github/workflows/publish-docker.yml
   workflow_dispatch:
 
@@ -33,10 +34,12 @@ jobs:
       id-token: write
     env:
       IMAGE_NAME: ghcr.io/formosa-gpgpu/formosa
-      XDG_CACHE_HOME: /tmp/formosa-xdg-cache
     steps:
-      - name: Report initial disk usage
-        run: df -h /
+      - name: Initialize runner paths and report disk usage
+        run: |
+          echo "ATTIC_PROFILE=$RUNNER_TEMP/formosa-attic-profile" >>"$GITHUB_ENV"
+          echo "XDG_CACHE_HOME=$RUNNER_TEMP/formosa-xdg-cache" >>"$GITHUB_ENV"
+          df -h /
 
       - name: Require main
         if: github.ref != 'refs/heads/main'
@@ -73,9 +76,13 @@ jobs:
             exit 1
           }
           echo "::add-mask::$ATTIC_SERVER"
-          nix profile add --inputs-from . nixpkgs#attic-client
-          attic login formosa "$ATTIC_SERVER" "$ATTIC_TOKEN" >/dev/null
-          attic use "formosa:$ATTIC_CACHE" >/dev/null
+          nix profile add \
+            --profile "$ATTIC_PROFILE" \
+            --inputs-from . \
+            nixpkgs#attic-client
+          "$ATTIC_PROFILE/bin/attic" login \
+            formosa "$ATTIC_SERVER" "$ATTIC_TOKEN" >/dev/null
+          "$ATTIC_PROFILE/bin/attic" use "formosa:$ATTIC_CACHE" >/dev/null
 
       - name: Report disk usage after setup
         run: df -h / /nix
@@ -95,7 +102,8 @@ jobs:
           archive="$RUNNER_TEMP/formosa-docker-env.tar.gz"
           cp --dereference result "$archive"
           rm result
-          nix profile remove attic-client
+          nix profile remove --profile "$ATTIC_PROFILE" attic-client
+          nix profile wipe-history --profile "$ATTIC_PROFILE"
           rm -rf -- "$XDG_CACHE_HOME/nix"
           nix store gc
           test -s "$archive"
@@ -140,18 +148,7 @@ jobs:
           set -euo pipefail
           image="$IMAGE_NAME:sha-$GITHUB_SHA"
           log="$RUNNER_TEMP/docker-push.log"
-          for delay in 0 10 20; do
-            sleep "$delay"
-            if docker push "$image" 2>&1 | tee "$log"; then
-              break
-            fi
-            if ! grep -Eqi \
-              '429|5[0-9]{2}|timeout|timed out|connection reset|unexpected EOF|temporar|service unavailable' \
-              "$log"; then
-              echo "::error::Non-transient GHCR push failure; not retrying"
-              exit 1
-            fi
-          done
+          bash .github/scripts/push-image.sh "$image" "$log"
           digest=$(sed -nE \
             's/.*digest: (sha256:[0-9a-f]{64}).*/\1/p' "$log" | tail -n 1)
           test -n "$digest"
@@ -172,16 +169,4 @@ jobs:
           image="$IMAGE_NAME:latest"
           log="$RUNNER_TEMP/docker-push-latest.log"
           docker tag "$IMAGE_ID" "$image"
-          for delay in 0 10 20; do
-            sleep "$delay"
-            if docker push "$image" 2>&1 | tee "$log"; then
-              exit 0
-            fi
-            if ! grep -Eqi \
-              '429|5[0-9]{2}|timeout|timed out|connection reset|unexpected EOF|temporar|service unavailable' \
-              "$log"; then
-              echo "::error::Non-transient GHCR push failure; not retrying"
-              exit 1
-            fi
-          done
-          exit 1
+          bash .github/scripts/push-image.sh "$image" "$log"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,167 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.nix"
+      - flake.lock
+      - CMakeLists.txt
+      - FormosaConfig.cmake.in
+      - "cmake/**"
+      - "addr_map/**"
+      - "fw/**"
+      - "hal/**"
+      - "libcomm/**"
+      - third-party/FreeRTOS-Kernel.cmake
+      - .github/workflows/publish-docker.yml
+  workflow_dispatch:
+
+concurrency:
+  group: publish-formosa-docker
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ${{ vars.DOCKER_RUNNER || 'ubuntu-24.04' }}
+    timeout-minutes: 360
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    env:
+      IMAGE_NAME: ghcr.io/formosa-gpgpu/formosa
+    steps:
+      - name: Require main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Docker images may only be published from main"
+          exit 1
+
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          enable_kvm: false
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Attic
+        env:
+          ATTIC_CACHE: ${{ vars.ATTIC_CACHE }}
+          ATTIC_SERVER: ${{ secrets.ATTIC_SERVER }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$ATTIC_CACHE" || {
+            echo "::error::ATTIC_CACHE repository variable is not configured"
+            exit 1
+          }
+          test -n "$ATTIC_SERVER" || {
+            echo "::error::ATTIC_SERVER repository secret is not configured"
+            exit 1
+          }
+          test -n "$ATTIC_TOKEN" || {
+            echo "::error::ATTIC_TOKEN repository secret is not configured"
+            exit 1
+          }
+          echo "::add-mask::$ATTIC_SERVER"
+          nix profile add --inputs-from . nixpkgs#attic-client
+          attic login formosa "$ATTIC_SERVER" "$ATTIC_TOKEN" >/dev/null
+          attic use "formosa:$ATTIC_CACHE" >/dev/null
+
+      - name: Report initial disk usage
+        run: df -h / /nix
+
+      - name: Build image archive
+        run: |
+          nix build .#formosa-docker-env \
+            --print-build-logs \
+            --option download-attempts 3
+          test -s result
+
+      - name: Preserve archive and reclaim Nix store
+        id: archive
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/formosa-docker-env.tar.gz"
+          cp --dereference result "$archive"
+          rm result
+          nix store gc
+          test -s "$archive"
+          available_kib=$(df --output=avail / | tail -n 1)
+          minimum_kib=$((7 * 1024 * 1024))
+          if ((available_kib < minimum_kib)); then
+            echo "::error::Only $((available_kib / 1024 / 1024)) GiB is free; Docker load requires at least 7 GiB"
+            exit 1
+          fi
+          echo "archive=$archive" >>"$GITHUB_OUTPUT"
+          df -h / /nix
+
+      - name: Load and tag image
+        id: image
+        env:
+          ARCHIVE: ${{ steps.archive.outputs.archive }}
+        run: |
+          set -euo pipefail
+          docker load --input "$ARCHIVE"
+          image_id=$(docker image ls \
+            --filter 'reference=formosa:*' \
+            --format '{{.ID}}' | head -n 1)
+          test -n "$image_id"
+          test "$(docker image inspect \
+            --format '{{.Os}}/{{.Architecture}}' "$image_id")" = linux/amd64
+          docker tag "$image_id" "$IMAGE_NAME:sha-$GITHUB_SHA"
+          rm "$ARCHIVE"
+          echo "image_id=$image_id" >>"$GITHUB_OUTPUT"
+          df -h / /var/lib/docker
+
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io \
+            --username "$GITHUB_ACTOR" \
+            --password-stdin
+
+      - name: Push immutable tag
+        id: push
+        run: |
+          set -euo pipefail
+          image="$IMAGE_NAME:sha-$GITHUB_SHA"
+          log="$RUNNER_TEMP/docker-push.log"
+          for delay in 0 10 20; do
+            sleep "$delay"
+            if docker push "$image" 2>&1 | tee "$log"; then
+              break
+            fi
+          done
+          digest=$(sed -nE \
+            's/.*digest: (sha256:[0-9a-f]{64}).*/\1/p' "$log" | tail -n 1)
+          test -n "$digest"
+          echo "digest=$digest" >>"$GITHUB_OUTPUT"
+
+      - name: Attest image
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Update latest tag
+        env:
+          IMAGE_ID: ${{ steps.image.outputs.image_id }}
+        run: |
+          set -euo pipefail
+          image="$IMAGE_NAME:latest"
+          docker tag "$IMAGE_ID" "$image"
+          for delay in 0 10 20; do
+            sleep "$delay"
+            if docker push "$image"; then
+              exit 0
+            fi
+          done
+          exit 1


### PR DESCRIPTION
## Summary

- publish the Nix formosa-docker-env image to ghcr.io/formosa-gpgpu/formosa on relevant main updates
- consume the internal Attic cache using repository secrets and a pull-only token
- publish immutable commit tags, GitHub provenance, and update latest only after attestation
- add a read-only pull-request validation job using actionlint and shellcheck

## Security

- publication runs only for trusted main events
- pull requests receive contents read permission only and cannot access Attic or package-write credentials
- ATTIC_SERVER and ATTIC_TOKEN remain repository secrets
- all third-party Actions are pinned to full commit SHAs

## Validation

- actionlint and shellcheck pass locally
- push retry helper covers success, permanent failure, and transient retry exhaustion
- temporary Attic profile installation and complete GC-root cleanup were verified
- final Standards and Spec reviews pass with no findings

## Required repository configuration before merge

Variables:
- DOCKER_RUNNER = ubuntu-24.04
- ATTIC_CACHE = formosa

Secrets:
- ATTIC_SERVER = private Attic base URL
- ATTIC_TOKEN = pull-only token for the formosa cache

The real Attic, Docker build, GHCR push, and attestation path will run for the first time after this PR reaches main.