### PR TITLE
ci: add GitHub regression workflow

### DIFF
--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -14,14 +14,110 @@ env:
 
 jobs:
   prepare:
-    name: Prepare regression matrix
+    name: Lint and prepare regression matrix
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 30
     outputs:
       presets: ${{ steps.presets.outputs.presets }}
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Select lint range
+        id: lint-range
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
+            from=$(git merge-base "$PR_BASE_SHA" "$PR_HEAD_SHA")
+            to=$PR_HEAD_SHA
+          else
+            from=$PUSH_BASE_SHA
+            to=$GITHUB_SHA
+            if [[ "$from" =~ ^0+$ ]]; then
+              from="$to^"
+            fi
+          fi
+          git cat-file -e "$from^{commit}"
+          git cat-file -e "$to^{commit}"
+          echo "from=$from" >>"$GITHUB_OUTPUT"
+          echo "to=$to" >>"$GITHUB_OUTPUT"
+
+      - name: Check third-party changes
+        if: github.event_name == 'pull_request'
+        env:
+          LINT_FROM: ${{ steps.lint-range.outputs.from }}
+          LINT_TO: ${{ steps.lint-range.outputs.to }}
+        run: |
+          set -euo pipefail
+          submodule_re='^third-party/(systemc|sol2|DRAMSys|fmt|argparse|elfio|'
+          submodule_re+='perfetto|glm|tomlplusplus|Catch2|softfloat|FreeRTOS-Kernel|'
+          submodule_re+='riscv-opcodes|riscv-tests|quill|DRAMUtils|nlohmann_json)(/|$)'
+          blocked=()
+          warned=()
+          while IFS= read -r -d '' path; do
+            if [[ "$path" =~ $submodule_re ]]; then
+              blocked+=("$path")
+            else
+              warned+=("$path")
+            fi
+          done < <(
+            git diff --name-only -z --diff-filter=ACDMRTUXB \
+              "$LINT_FROM" "$LINT_TO" -- third-party/
+          )
+          if ((${#warned[@]})); then
+            echo '::warning title=third-party files changed::CONTRIBUTING.md asks contributors to avoid third-party changes unless requested by a maintainer.'
+            printf 'Third-party changes:\n  %s\n' "${warned[@]}"
+          fi
+          if ((${#blocked[@]})); then
+            echo '::error title=expanded submodule changed::These files are exported from internal submodules. Ask a maintainer to update the internal submodule revision instead.'
+            printf 'Expanded submodule changes:\n  %s\n' "${blocked[@]}"
+            exit 1
+          fi
+
+      - name: Pull FORMOSA environment
+        run: docker pull "$FORMOSA_CI_IMAGE"
+
+      - name: Lint changed files
+        env:
+          LINT_FROM: ${{ steps.lint-range.outputs.from }}
+          LINT_TO: ${{ steps.lint-range.outputs.to }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --env HOME=/tmp \
+            --env TMP=/tmp \
+            --env TEMP=/tmp \
+            --env TEMPDIR=/tmp \
+            --env TMPDIR=/tmp \
+            --env NIX_BUILD_TOP=/tmp \
+            --tmpfs /tmp:rw,exec,mode=1777 \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$FORMOSA_CI_IMAGE" \
+            bash -c '
+              set -eo pipefail
+              set +u
+              rc=(/nix/store/*-nix-shell-rc)
+              if (( ${#rc[@]} != 1 )); then
+                printf "expected one Nix shell rc, found %d\n" "${#rc[@]}" >&2
+                exit 1
+              fi
+              source "${rc[0]}"
+              set -euo pipefail
+
+              status=0
+              pre-commit run --from-ref "$1" --to-ref "$2" || status=$?
+              git diff --no-ext-diff
+              exit "$status"
+            ' bash "$LINT_FROM" "$LINT_TO"
 
       - name: Read regression presets
         id: presets

--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -1,0 +1,211 @@
+name: FORMOSA regression
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  FORMOSA_CI_IMAGE: ghcr.io/formosa-gpgpu/formosa:latest
+
+jobs:
+  prepare:
+    name: Prepare regression matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.presets.outputs.matrix }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Read functional presets
+        id: presets
+        run: |
+          set -euo pipefail
+          matrix=$(
+            jq -ce '
+              . as $root
+              | [
+                  $root.testPresets[]
+                  | select(.name != "perf.opencl")
+                  | .name as $preset
+                  | {
+                      preset: $preset,
+                      coverage: (
+                        [
+                          $root.configurePresets[]
+                          | select(.name == $preset)
+                          | (.cacheVariables // {})
+                          | to_entries[]
+                          | select(
+                              (.key | endswith("_ENABLE_GCOV")) and
+                              .value == "ON"
+                            )
+                        ]
+                        | length > 0
+                      )
+                    }
+                ]
+              | if
+                  (length == 16) and
+                  ((map(.preset) | unique | length) == 16)
+                then .
+                else error("expected 16 unique functional presets")
+                end
+            ' CMakePresets.json
+          )
+          echo "matrix=$matrix" >>"$GITHUB_OUTPUT"
+
+  regression:
+    name: Regression (${{ matrix.preset }})
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Report runner resources
+        run: |
+          nproc
+          free -h
+          df -h / /var/lib/docker
+
+      - name: Pull FORMOSA environment
+        run: docker pull "$FORMOSA_CI_IMAGE"
+
+      - name: Configure, build, and test
+        id: functional
+        env:
+          FSA_PRESET: ${{ matrix.preset }}
+        run: |
+          set -euo pipefail
+          test ! -e build
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --env HOME=/tmp \
+            --env TMP=/tmp \
+            --env TEMP=/tmp \
+            --env TEMPDIR=/tmp \
+            --env TMPDIR=/tmp \
+            --env NIX_BUILD_TOP=/tmp \
+            --tmpfs /tmp:rw,exec,mode=1777 \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$FORMOSA_CI_IMAGE" \
+            bash -c '
+              set -eo pipefail
+              set +u
+              rc=(/nix/store/*-nix-shell-rc)
+              if (( ${#rc[@]} != 1 )); then
+                printf "expected one Nix shell rc, found %d\n" "${#rc[@]}" >&2
+                exit 1
+              fi
+              source "${rc[0]}"
+              set -euo pipefail
+
+              cmake -B build --preset "$1"
+              cmake --build build
+              ctest --test-dir build --preset "$1" -j --output-on-failure
+            ' bash "$FSA_PRESET"
+
+      - name: Generate coverage
+        id: coverage
+        if: ${{ matrix.coverage }}
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --env HOME=/tmp \
+            --env TMP=/tmp \
+            --env TEMP=/tmp \
+            --env TEMPDIR=/tmp \
+            --env TMPDIR=/tmp \
+            --env NIX_BUILD_TOP=/tmp \
+            --tmpfs /tmp:rw,exec,mode=1777 \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$FORMOSA_CI_IMAGE" \
+            bash -c '
+              set -eo pipefail
+              set +u
+              rc=(/nix/store/*-nix-shell-rc)
+              if (( ${#rc[@]} != 1 )); then
+                printf "expected one Nix shell rc, found %d\n" "${#rc[@]}" >&2
+                exit 1
+              fi
+              source "${rc[0]}"
+              set -euo pipefail
+
+              gcovr -e third-party \
+                --xml-pretty \
+                --exclude-unreachable-branches \
+                --gcov-ignore-parse-errors suspicious_hits.warn \
+                --gcov-ignore-parse-errors negative_hits.warn \
+                --print-summary \
+                -o build/coverage.xml \
+                --root /workspace \
+                --object-directory build
+            '
+
+      - name: Upload regression outputs
+        id: artifacts
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: regression-${{ matrix.preset }}
+          path: |
+            build/testing-out/*.toml
+            build/coverage.xml
+          if-no-files-found: ignore
+          retention-days: 2
+
+      - name: Summarize lane
+        if: ${{ always() }}
+        env:
+          ARTIFACT_OUTCOME: ${{ steps.artifacts.outcome }}
+          COVERAGE_OUTCOME: ${{ steps.coverage.outcome }}
+          FUNCTIONAL_OUTCOME: ${{ steps.functional.outcome }}
+          FSA_COVERAGE: ${{ matrix.coverage }}
+          FSA_PRESET: ${{ matrix.preset }}
+        run: |
+          {
+            echo "## $FSA_PRESET"
+            echo
+            echo "| Result | Status |"
+            echo "| --- | --- |"
+            echo "| Functional | ${FUNCTIONAL_OUTCOME:-not-run} |"
+            if [[ "$FSA_COVERAGE" == "true" ]]; then
+              echo "| Coverage | ${COVERAGE_OUTCOME:-not-run} |"
+            else
+              echo "| Coverage | disabled |"
+            fi
+            echo "| Artifacts | ${ARTIFACT_OUTCOME:-not-run} |"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+  aggregate:
+    name: Functional regression
+    if: ${{ always() }}
+    needs: regression
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Require every functional lane
+        env:
+          REGRESSION_RESULT: ${{ needs.regression.result }}
+        run: |
+          if [[ "$REGRESSION_RESULT" != "success" ]]; then
+            echo "Functional regression result: $REGRESSION_RESULT" >&2
+            exit 1
+          fi

--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -50,7 +50,6 @@ jobs:
           FSA_PRESET: ${{ matrix.preset }}
         run: |
           set -euo pipefail
-          test ! -e build
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             --env HOME=/tmp \
@@ -76,7 +75,7 @@ jobs:
 
               cmake -B build --preset "$1"
               cmake --build build
-              ctest --test-dir build --preset "$1" -j --timeout 3000 --output-on-failure
+              ctest --test-dir build --preset "$1" -j --timeout 3000
               gcovr -e third-party \
                 --print-summary \
                 -o build/coverage.txt \

--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -3,14 +3,17 @@ name: FORMOSA regression
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 env:
-  FORMOSA_CI_IMAGE: ghcr.io/formosa-gpgpu/formosa:latest
+  FORMOSA_CI_DEFAULT_IMAGE: ghcr.io/formosa-gpgpu/formosa:latest
 
 jobs:
   prepare:
@@ -18,6 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
+      image: ${{ steps.image.outputs.image }}
       presets: ${{ steps.presets.outputs.presets }}
     steps:
       - name: Check out repository
@@ -40,7 +44,7 @@ jobs:
           else
             from=$PUSH_BASE_SHA
             to=$GITHUB_SHA
-            if [[ "$from" =~ ^0+$ ]]; then
+            if [[ -z "$from" || "$from" =~ ^0+$ ]]; then
               from="$to^"
             fi
           fi
@@ -81,13 +85,24 @@ jobs:
             exit 1
           fi
 
-      - name: Pull FORMOSA environment
-        run: docker pull "$FORMOSA_CI_IMAGE"
+      - name: Resolve FORMOSA environment
+        id: image
+        env:
+          REQUESTED_IMAGE: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          image=${REQUESTED_IMAGE:-$FORMOSA_CI_DEFAULT_IMAGE}
+          docker pull "$image"
+          image_ref=$(docker image inspect \
+            --format '{{index .RepoDigests 0}}' "$image")
+          [[ "$image_ref" =~ ^ghcr\.io/formosa-gpgpu/formosa@sha256:[0-9a-f]{64}$ ]]
+          echo "image=$image_ref" >>"$GITHUB_OUTPUT"
 
       - name: Lint changed files
         env:
           LINT_FROM: ${{ steps.lint-range.outputs.from }}
           LINT_TO: ${{ steps.lint-range.outputs.to }}
+          FORMOSA_CI_IMAGE: ${{ steps.image.outputs.image }}
         run: |
           set -euo pipefail
           docker run --rm \
@@ -130,6 +145,8 @@ jobs:
     needs: prepare
     runs-on: ubuntu-24.04
     timeout-minutes: 180
+    env:
+      FORMOSA_CI_IMAGE: ${{ needs.prepare.outputs.image }}
     strategy:
       fail-fast: false
       matrix:
@@ -181,7 +198,7 @@ jobs:
 
   public-ci:
     name: Public CI
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name == 'pull_request' }}
     needs:
       - prepare
       - regression

--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -178,3 +178,21 @@ jobs:
                 --root /workspace \
                 --object-directory build || true
             ' bash "$FSA_PRESET"
+
+  public-ci:
+    name: Public CI
+    if: ${{ always() }}
+    needs:
+      - prepare
+      - regression
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Require lint and regression
+        env:
+          PREPARE_RESULT: ${{ needs.prepare.result }}
+          REGRESSION_RESULT: ${{ needs.regression.result }}
+        run: |
+          set -euo pipefail
+          test "$PREPARE_RESULT" = success
+          test "$REGRESSION_RESULT" = success

--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -76,7 +76,7 @@ jobs:
 
               cmake -B build --preset "$1"
               cmake --build build
-              ctest --test-dir build --preset "$1" -j --output-on-failure
+              ctest --test-dir build --preset "$1" -j --timeout 3000 --output-on-failure
               gcovr -e third-party \
                 --print-summary \
                 -o build/coverage.txt \

--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -18,48 +18,16 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
-      matrix: ${{ steps.presets.outputs.matrix }}
+      presets: ${{ steps.presets.outputs.presets }}
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Read functional presets
+      - name: Read regression presets
         id: presets
         run: |
           set -euo pipefail
-          matrix=$(
-            jq -ce '
-              . as $root
-              | [
-                  $root.testPresets[]
-                  | select(.name != "perf.opencl")
-                  | .name as $preset
-                  | {
-                      preset: $preset,
-                      coverage: (
-                        [
-                          $root.configurePresets[]
-                          | select(.name == $preset)
-                          | (.cacheVariables // {})
-                          | to_entries[]
-                          | select(
-                              (.key | endswith("_ENABLE_GCOV")) and
-                              .value == "ON"
-                            )
-                        ]
-                        | length > 0
-                      )
-                    }
-                ]
-              | if
-                  (length == 16) and
-                  ((map(.preset) | unique | length) == 16)
-                then .
-                else error("expected 16 unique functional presets")
-                end
-            ' CMakePresets.json
-          )
-          echo "matrix=$matrix" >>"$GITHUB_OUTPUT"
+          echo "presets=$(jq -ce '[.testPresets[].name | select(. != "perf.opencl")]' CMakePresets.json)" >>"$GITHUB_OUTPUT"
 
   regression:
     name: Regression (${{ matrix.preset }})
@@ -69,22 +37,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+        preset: ${{ fromJSON(needs.prepare.outputs.presets) }}
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Report runner resources
-        run: |
-          nproc
-          free -h
-          df -h / /var/lib/docker
-
       - name: Pull FORMOSA environment
         run: docker pull "$FORMOSA_CI_IMAGE"
 
-      - name: Configure, build, and test
-        id: functional
+      - name: Configure, build, test, and report coverage
         env:
           FSA_PRESET: ${{ matrix.preset }}
         run: |
@@ -116,96 +77,9 @@ jobs:
               cmake -B build --preset "$1"
               cmake --build build
               ctest --test-dir build --preset "$1" -j --output-on-failure
-            ' bash "$FSA_PRESET"
-
-      - name: Generate coverage
-        id: coverage
-        if: ${{ matrix.coverage }}
-        continue-on-error: true
-        run: |
-          set -euo pipefail
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            --env HOME=/tmp \
-            --env TMP=/tmp \
-            --env TEMP=/tmp \
-            --env TEMPDIR=/tmp \
-            --env TMPDIR=/tmp \
-            --env NIX_BUILD_TOP=/tmp \
-            --tmpfs /tmp:rw,exec,mode=1777 \
-            --volume "$GITHUB_WORKSPACE:/workspace" \
-            --workdir /workspace \
-            "$FORMOSA_CI_IMAGE" \
-            bash -c '
-              set -eo pipefail
-              set +u
-              rc=(/nix/store/*-nix-shell-rc)
-              if (( ${#rc[@]} != 1 )); then
-                printf "expected one Nix shell rc, found %d\n" "${#rc[@]}" >&2
-                exit 1
-              fi
-              source "${rc[0]}"
-              set -euo pipefail
-
               gcovr -e third-party \
-                --xml-pretty \
-                --exclude-unreachable-branches \
-                --gcov-ignore-parse-errors suspicious_hits.warn \
-                --gcov-ignore-parse-errors negative_hits.warn \
                 --print-summary \
-                -o build/coverage.xml \
+                -o build/coverage.txt \
                 --root /workspace \
-                --object-directory build
-            '
-
-      - name: Upload regression outputs
-        id: artifacts
-        if: ${{ always() }}
-        continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: regression-${{ matrix.preset }}
-          path: |
-            build/testing-out/*.toml
-            build/coverage.xml
-          if-no-files-found: ignore
-          retention-days: 2
-
-      - name: Summarize lane
-        if: ${{ always() }}
-        env:
-          ARTIFACT_OUTCOME: ${{ steps.artifacts.outcome }}
-          COVERAGE_OUTCOME: ${{ steps.coverage.outcome }}
-          FUNCTIONAL_OUTCOME: ${{ steps.functional.outcome }}
-          FSA_COVERAGE: ${{ matrix.coverage }}
-          FSA_PRESET: ${{ matrix.preset }}
-        run: |
-          {
-            echo "## $FSA_PRESET"
-            echo
-            echo "| Result | Status |"
-            echo "| --- | --- |"
-            echo "| Functional | ${FUNCTIONAL_OUTCOME:-not-run} |"
-            if [[ "$FSA_COVERAGE" == "true" ]]; then
-              echo "| Coverage | ${COVERAGE_OUTCOME:-not-run} |"
-            else
-              echo "| Coverage | disabled |"
-            fi
-            echo "| Artifacts | ${ARTIFACT_OUTCOME:-not-run} |"
-          } >>"$GITHUB_STEP_SUMMARY"
-
-  aggregate:
-    name: Functional regression
-    if: ${{ always() }}
-    needs: regression
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - name: Require every functional lane
-        env:
-          REGRESSION_RESULT: ${{ needs.regression.result }}
-        run: |
-          if [[ "$REGRESSION_RESULT" != "success" ]]; then
-            echo "Functional regression result: $REGRESSION_RESULT" >&2
-            exit 1
-          fi
+                --object-directory build || true
+            ' bash "$FSA_PRESET"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: publish-formosa-docker-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  queue: max
 
 jobs:
   detect:
@@ -85,6 +85,7 @@ jobs:
             nixpkgs#shellcheck \
             --command bash -euo pipefail -c '
               actionlint -shellcheck shellcheck \
+                -ignore "unexpected key \"queue\" for \"concurrency\"" \
                 .github/workflows/formosa-regression.yml \
                 .github/workflows/publish-docker.yml
               shellcheck .github/scripts/push-image.sh
@@ -273,8 +274,14 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx imagetools create \
+            --prefer-index=false \
             --tag "$IMAGE_NAME:latest" \
             "$IMAGE_REF"
+          latest_digest=$(docker buildx imagetools inspect \
+            --format '{{.Manifest.Digest}}' \
+            "$IMAGE_NAME:latest")
+          candidate_digest=${IMAGE_REF##*@}
+          test "$latest_digest" = "$candidate_digest"
 
   public-ci:
     name: Public CI

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -278,8 +278,8 @@ jobs:
             --tag "$IMAGE_NAME:latest" \
             "$IMAGE_REF"
           latest_digest=$(docker buildx imagetools inspect \
-            --format '{{.Manifest.Digest}}' \
-            "$IMAGE_NAME:latest")
+            --format '{{json .Manifest.Digest}}' \
+            "$IMAGE_NAME:latest" | jq -r .)
           candidate_digest=${IMAGE_REF##*@}
           test "$latest_digest" = "$candidate_digest"
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -4,29 +4,63 @@ on:
   pull_request:
     paths:
       - .github/scripts/push-image.sh
+      - .github/workflows/formosa-regression.yml
       - .github/workflows/publish-docker.yml
   push:
     branches: [main]
-    paths:
-      - "**/*.nix"
-      - flake.lock
-      - CMakeLists.txt
-      - FormosaConfig.cmake.in
-      - "cmake/**"
-      - "addr_map/**"
-      - "fw/**"
-      - "hal/**"
-      - "libcomm/**"
-      - third-party/FreeRTOS-Kernel.cmake
-      - .github/scripts/push-image.sh
-      - .github/workflows/publish-docker.yml
   workflow_dispatch:
 
 concurrency:
-  group: publish-formosa-docker
-  cancel-in-progress: true
+  group: publish-formosa-docker-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  detect:
+    name: Detect image changes
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      image_affecting: ${{ steps.changes.outputs.image_affecting }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Classify changes
+        id: changes
+        env:
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          from=$PUSH_BASE_SHA
+          if [[ "$from" =~ ^0+$ || -z "$from" ]]; then
+            from="$GITHUB_SHA^"
+          fi
+
+          image_affecting=true
+          if [[ "$GITHUB_EVENT_NAME" != workflow_dispatch ]] &&
+            git diff --quiet "$from" "$GITHUB_SHA" -- \
+              ':(glob)**/*.nix' \
+              flake.lock \
+              CMakeLists.txt \
+              FormosaConfig.cmake.in \
+              'cmake/**' \
+              'addr_map/**' \
+              'fw/**' \
+              'hal/**' \
+              'libcomm/**' \
+              third-party/FreeRTOS-Kernel.cmake \
+              .github/scripts/push-image.sh \
+              .github/workflows/publish-docker.yml; then
+            image_affecting=false
+          fi
+          echo "image_affecting=$image_affecting" >>"$GITHUB_OUTPUT"
+
   validate:
     name: Validate workflow
     if: github.event_name == 'pull_request'
@@ -50,15 +84,20 @@ jobs:
             nixpkgs#actionlint \
             nixpkgs#shellcheck \
             --command bash -euo pipefail -c '
-              actionlint -shellcheck shellcheck .github/workflows/publish-docker.yml
+              actionlint -shellcheck shellcheck \
+                .github/workflows/formosa-regression.yml \
+                .github/workflows/publish-docker.yml
               shellcheck .github/scripts/push-image.sh
             '
 
   publish:
     name: Build and publish
-    if: github.event_name != 'pull_request'
+    needs: detect
+    if: ${{ needs.detect.result == 'success' && needs.detect.outputs.image_affecting == 'true' }}
     runs-on: ${{ vars.DOCKER_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 360
+    outputs:
+      image_ref: ${{ steps.push.outputs.image_ref }}
     permissions:
       contents: read
       packages: write
@@ -149,7 +188,6 @@ jobs:
           df -h / /nix
 
       - name: Load and tag image
-        id: image
         env:
           ARCHIVE: ${{ steps.archive.outputs.archive }}
         run: |
@@ -163,7 +201,6 @@ jobs:
             --format '{{.Os}}/{{.Architecture}}' "$image_id")" = linux/amd64
           docker tag "$image_id" "$IMAGE_NAME:sha-$GITHUB_SHA"
           rm "$ARCHIVE"
-          echo "image_id=$image_id" >>"$GITHUB_OUTPUT"
           df -h / /var/lib/docker
 
       - name: Log in to GHCR
@@ -185,6 +222,7 @@ jobs:
             's/.*digest: (sha256:[0-9a-f]{64}).*/\1/p' "$log" | tail -n 1)
           test -n "$digest"
           echo "digest=$digest" >>"$GITHUB_OUTPUT"
+          echo "image_ref=$IMAGE_NAME@$digest" >>"$GITHUB_OUTPUT"
 
       - name: Attest image
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -194,12 +232,71 @@ jobs:
           push-to-registry: true
           create-storage-record: false
 
-      - name: Update latest tag
+  regression:
+    name: Regression
+    needs:
+      - detect
+      - publish
+    if: >-
+      ${{ always() &&
+          needs.detect.result == 'success' &&
+          (needs.detect.outputs.image_affecting == 'false' ||
+           needs.publish.result == 'success') }}
+    uses: ./.github/workflows/formosa-regression.yml
+    with:
+      image: ${{ needs.publish.outputs.image_ref || 'ghcr.io/formosa-gpgpu/formosa:latest' }}
+    permissions:
+      contents: read
+
+  promote:
+    name: Promote latest
+    needs:
+      - publish
+      - regression
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/formosa-gpgpu/formosa
+      IMAGE_REF: ${{ needs.publish.outputs.image_ref }}
+    steps:
+      - name: Log in to GHCR
         env:
-          IMAGE_ID: ${{ steps.image.outputs.image_id }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io \
+            --username "$GITHUB_ACTOR" \
+            --password-stdin
+
+      - name: Update latest tag
         run: |
           set -euo pipefail
-          image="$IMAGE_NAME:latest"
-          log="$RUNNER_TEMP/docker-push-latest.log"
-          docker tag "$IMAGE_ID" "$image"
-          bash .github/scripts/push-image.sh "$image" "$log"
+          docker buildx imagetools create \
+            --tag "$IMAGE_NAME:latest" \
+            "$IMAGE_REF"
+
+  public-ci:
+    name: Public CI
+    if: ${{ always() && needs.detect.result != 'skipped' }}
+    needs:
+      - detect
+      - publish
+      - regression
+      - promote
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Require regression
+        env:
+          IMAGE_AFFECTING: ${{ needs.detect.outputs.image_affecting }}
+          DETECT_RESULT: ${{ needs.detect.result }}
+          REGRESSION_RESULT: ${{ needs.regression.result }}
+          PROMOTE_RESULT: ${{ needs.promote.result }}
+        run: |
+          set -euo pipefail
+          test "$DETECT_RESULT" = success
+          test "$REGRESSION_RESULT" = success
+          if [[ "$IMAGE_AFFECTING" == true ]]; then
+            test "$PROMOTE_RESULT" = success
+          fi


### PR DESCRIPTION
## Summary

- add a GitHub Actions regression workflow for the public repository
- lint changed files in `ghcr.io/formosa-gpgpu/formosa:latest` before starting regression jobs
- reject pull-request changes to directories exported from internal submodules and warn on other `third-party/` changes
- dynamically run every test preset except `perf.opencl`
- mount the checked-out workspace into the container and run with the runner's UID/GID
- configure, build, and test each preset with a 3000-second per-test timeout
- report coverage without making coverage generation block the regression result
- expose a stable `Public CI` check for the internal public-sync importer

## Validation

- `git diff --check main...HEAD`
- `actionlint` with `shellcheck`
- public-image `pre-commit run --from-ref main --to-ref HEAD`
- the previous workflow revision completed all 16 GitHub regression lanes successfully; the updated workflow will rerun them on this PR
- the full local regression matrix was not rerun because the host CPU was saturated
