### PR TITLE
ci: rebuild public regression on workflows.lua impact analysis

### DIFF
--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -85,6 +85,18 @@ jobs:
             exit 1
           fi
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          enable_kvm: false
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate generated presets
+        run: |
+          set -euo pipefail
+          test -s CMakePresets.json
+          nix shell --inputs-from . nixpkgs#xmake --command xmake workflow check
+
       - name: Resolve FORMOSA environment
         id: image
         env:
@@ -97,38 +109,6 @@ jobs:
             --format '{{index .RepoDigests 0}}' "$image")
           [[ "$image_ref" =~ ^ghcr\.io/formosa-gpgpu/formosa@sha256:[0-9a-f]{64}$ ]]
           echo "image=$image_ref" >>"$GITHUB_OUTPUT"
-
-      - name: Validate generated presets
-        env:
-          FORMOSA_CI_IMAGE: ${{ steps.image.outputs.image }}
-        run: |
-          set -euo pipefail
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            --env HOME=/tmp \
-            --env TMP=/tmp \
-            --env TEMP=/tmp \
-            --env TEMPDIR=/tmp \
-            --env TMPDIR=/tmp \
-            --env NIX_BUILD_TOP=/tmp \
-            --tmpfs /tmp:rw,exec,mode=1777 \
-            --volume "$GITHUB_WORKSPACE:/workspace" \
-            --workdir /workspace \
-            "$FORMOSA_CI_IMAGE" \
-            bash -c '
-              set -eo pipefail
-              set +u
-              rc=(/nix/store/*-nix-shell-rc)
-              if (( ${#rc[@]} != 1 )); then
-                printf "expected one Nix shell rc, found %d\n" "${#rc[@]}" >&2
-                exit 1
-              fi
-              source "${rc[0]}"
-              set -euo pipefail
-
-              test -s CMakePresets.json
-              xmake workflow check
-            '
 
       - name: Lint changed files
         if: steps.range.outputs.use_all != 'true'
@@ -174,19 +154,64 @@ jobs:
     timeout-minutes: 180
     env:
       FORMOSA_CI_IMAGE: ${{ needs.plan.outputs.image }}
-      REGRESSION_BASE: ${{ needs.plan.outputs.base }}
-      REGRESSION_HEAD: ${{ needs.plan.outputs.head }}
-      REGRESSION_USE_ALL: ${{ needs.plan.outputs.use_all }}
     steps:
       - name: Check out repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          enable_kvm: false
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate regression presets
+        id: generate
+        env:
+          REGRESSION_BASE: ${{ needs.plan.outputs.base }}
+          REGRESSION_HEAD: ${{ needs.plan.outputs.head }}
+          REGRESSION_USE_ALL: ${{ needs.plan.outputs.use_all }}
+        run: |
+          set -euo pipefail
+          use_all=$REGRESSION_USE_ALL
+          # workflows.lua, xmake/, and generated presets have no owning
+          # component, so a change there selects no suites. Fall back to
+          # the full run to avoid silently skipping validation.
+          # (xmake here comes from pinned nixpkgs, not the Docker image,
+          # which may predate the xmake workflow tooling.)
+          if [[ "$use_all" != true ]]; then
+            if git diff --name-only "$REGRESSION_BASE" "$REGRESSION_HEAD" -- \
+              workflows.lua xmake/ CMakePresets.json CMakeUserPresets.json .github/ \
+              | grep -q .; then
+              echo "Workflow definition changed; running full regression."
+              use_all=true
+            fi
+          fi
+          if [[ "$use_all" == true ]]; then
+            nix shell --inputs-from . nixpkgs#xmake --command \
+              xmake workflow regression \
+              --profile=debug --adapter=cmake --all --generate
+          else
+            nix shell --inputs-from . nixpkgs#xmake --command \
+              xmake workflow regression \
+              --profile=debug --adapter=cmake \
+              --base "$REGRESSION_BASE" --head "$REGRESSION_HEAD" \
+              --generate
+          fi
+          if jq -e '.testPresets // [] | length > 0' CMakeUserPresets.json >/dev/null; then
+            echo "has_tests=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "No affected test suites; skipping build and test."
+            echo "has_tests=false" >>"$GITHUB_OUTPUT"
+          fi
+
       - name: Pull FORMOSA environment
+        if: steps.generate.outputs.has_tests == 'true'
         run: docker pull "$FORMOSA_CI_IMAGE"
 
-      - name: Plan, build, and test affected suites
+      - name: Build and test affected suites
+        if: steps.generate.outputs.has_tests == 'true'
         run: |
           set -euo pipefail
           docker run --rm \
@@ -197,9 +222,6 @@ jobs:
             --env TEMPDIR=/tmp \
             --env TMPDIR=/tmp \
             --env NIX_BUILD_TOP=/tmp \
-            --env REGRESSION_BASE="$REGRESSION_BASE" \
-            --env REGRESSION_HEAD="$REGRESSION_HEAD" \
-            --env REGRESSION_USE_ALL="$REGRESSION_USE_ALL" \
             --tmpfs /tmp:rw,exec,mode=1777 \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
@@ -214,34 +236,6 @@ jobs:
               fi
               source "${rc[0]}"
               set -euo pipefail
-
-              git config --global --add safe.directory /workspace
-              # workflows.lua, xmake/, and generated presets have no owning
-              # component, so a change there selects no suites. Fall back to
-              # the full run to avoid silently skipping validation.
-              if [[ "$REGRESSION_USE_ALL" != true ]]; then
-                if git diff --name-only "$REGRESSION_BASE" "$REGRESSION_HEAD" -- \
-                  workflows.lua xmake/ CMakePresets.json CMakeUserPresets.json .github/ \
-                  | grep -q .; then
-                  echo "Workflow definition changed; running full regression."
-                  REGRESSION_USE_ALL=true
-                fi
-              fi
-
-              if [[ "$REGRESSION_USE_ALL" == true ]]; then
-                xmake workflow regression \
-                  --profile=debug --adapter=cmake --all --generate
-              else
-                xmake workflow regression \
-                  --profile=debug --adapter=cmake \
-                  --base "$REGRESSION_BASE" --head "$REGRESSION_HEAD" \
-                  --generate
-              fi
-
-              if ! jq -e ".testPresets // [] | length > 0" CMakeUserPresets.json >/dev/null; then
-                echo "No affected test suites; skipping build and test."
-                exit 0
-              fi
 
               cmake --workflow --preset regression.debug
               ctest --preset regression.debug -j --timeout 3000

--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -16,48 +16,59 @@ env:
   FORMOSA_CI_DEFAULT_IMAGE: ghcr.io/formosa-gpgpu/formosa:latest
 
 jobs:
-  prepare:
-    name: Lint and prepare regression matrix
+  plan:
+    name: Lint and plan regression
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
       image: ${{ steps.image.outputs.image }}
-      presets: ${{ steps.presets.outputs.presets }}
+      base: ${{ steps.range.outputs.base }}
+      head: ${{ steps.range.outputs.head }}
+      use_all: ${{ steps.range.outputs.use_all }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Select lint range
-        id: lint-range
+      - name: Set up xmake
+        uses: xmake-io/github-action-setup-xmake@3a1a5dddfc7fa625d9a698738334bf55655a861a # v1.2.5
+        with:
+          xmake-version: "3.0.4"
+
+      - name: Validate generated presets
+        run: |
+          set -euo pipefail
+          test -s CMakePresets.json
+          xmake workflow check
+
+      - name: Select regression range
+        id: range
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PUSH_BASE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
             from=$(git merge-base "$PR_BASE_SHA" "$PR_HEAD_SHA")
             to=$PR_HEAD_SHA
+            git cat-file -e "$from^{commit}"
+            git cat-file -e "$to^{commit}"
+            {
+              echo "base=$from"
+              echo "head=$to"
+              echo "use_all=false"
+            } >>"$GITHUB_OUTPUT"
           else
-            from=$PUSH_BASE_SHA
-            to=$GITHUB_SHA
-            if [[ -z "$from" || "$from" =~ ^0+$ ]]; then
-              from="$to^"
-            fi
+            echo "use_all=true" >>"$GITHUB_OUTPUT"
           fi
-          git cat-file -e "$from^{commit}"
-          git cat-file -e "$to^{commit}"
-          echo "from=$from" >>"$GITHUB_OUTPUT"
-          echo "to=$to" >>"$GITHUB_OUTPUT"
 
       - name: Check third-party changes
-        if: github.event_name == 'pull_request'
+        if: steps.range.outputs.use_all != 'true'
         env:
-          LINT_FROM: ${{ steps.lint-range.outputs.from }}
-          LINT_TO: ${{ steps.lint-range.outputs.to }}
+          LINT_FROM: ${{ steps.range.outputs.base }}
+          LINT_TO: ${{ steps.range.outputs.head }}
         run: |
           set -euo pipefail
           submodule_re='^third-party/(systemc|sol2|DRAMSys|fmt|argparse|elfio|'
@@ -99,9 +110,10 @@ jobs:
           echo "image=$image_ref" >>"$GITHUB_OUTPUT"
 
       - name: Lint changed files
+        if: steps.range.outputs.use_all != 'true'
         env:
-          LINT_FROM: ${{ steps.lint-range.outputs.from }}
-          LINT_TO: ${{ steps.lint-range.outputs.to }}
+          LINT_FROM: ${{ steps.range.outputs.base }}
+          LINT_TO: ${{ steps.range.outputs.head }}
           FORMOSA_CI_IMAGE: ${{ steps.image.outputs.image }}
         run: |
           set -euo pipefail
@@ -134,33 +146,26 @@ jobs:
               exit "$status"
             ' bash "$LINT_FROM" "$LINT_TO"
 
-      - name: Read regression presets
-        id: presets
-        run: |
-          set -euo pipefail
-          echo "presets=$(jq -ce '[.testPresets[].name | select(. != "perf.opencl")]' CMakePresets.json)" >>"$GITHUB_OUTPUT"
-
   regression:
-    name: Regression (${{ matrix.preset }})
-    needs: prepare
+    name: Regression (regression.debug)
+    needs: plan
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     env:
-      FORMOSA_CI_IMAGE: ${{ needs.prepare.outputs.image }}
-    strategy:
-      fail-fast: false
-      matrix:
-        preset: ${{ fromJSON(needs.prepare.outputs.presets) }}
+      FORMOSA_CI_IMAGE: ${{ needs.plan.outputs.image }}
+      REGRESSION_BASE: ${{ needs.plan.outputs.base }}
+      REGRESSION_HEAD: ${{ needs.plan.outputs.head }}
+      REGRESSION_USE_ALL: ${{ needs.plan.outputs.use_all }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
 
       - name: Pull FORMOSA environment
         run: docker pull "$FORMOSA_CI_IMAGE"
 
-      - name: Configure, build, test, and report coverage
-        env:
-          FSA_PRESET: ${{ matrix.preset }}
+      - name: Plan, build, and test affected suites
         run: |
           set -euo pipefail
           docker run --rm \
@@ -171,6 +176,9 @@ jobs:
             --env TEMPDIR=/tmp \
             --env TMPDIR=/tmp \
             --env NIX_BUILD_TOP=/tmp \
+            --env REGRESSION_BASE="$REGRESSION_BASE" \
+            --env REGRESSION_HEAD="$REGRESSION_HEAD" \
+            --env REGRESSION_USE_ALL="$REGRESSION_USE_ALL" \
             --tmpfs /tmp:rw,exec,mode=1777 \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
@@ -186,30 +194,52 @@ jobs:
               source "${rc[0]}"
               set -euo pipefail
 
-              cmake -B build --preset "$1"
-              cmake --build build
-              ctest --test-dir build --preset "$1" -j --timeout 3000
-              gcovr -e third-party \
-                --print-summary \
-                -o build/coverage.txt \
-                --root /workspace \
-                --object-directory build || true
-            ' bash "$FSA_PRESET"
+              git config --global --add safe.directory /workspace
+              # workflows.lua, xmake/, and generated presets have no owning
+              # component, so a change there selects no suites. Fall back to
+              # the full run to avoid silently skipping validation.
+              if [[ "$REGRESSION_USE_ALL" != true ]]; then
+                if git diff --name-only "$REGRESSION_BASE" "$REGRESSION_HEAD" -- \
+                  workflows.lua xmake/ CMakePresets.json CMakeUserPresets.json .github/ \
+                  | grep -q .; then
+                  echo "Workflow definition changed; running full regression."
+                  REGRESSION_USE_ALL=true
+                fi
+              fi
+
+              if [[ "$REGRESSION_USE_ALL" == true ]]; then
+                xmake workflow regression \
+                  --profile=debug --adapter=cmake --all --generate
+              else
+                xmake workflow regression \
+                  --profile=debug --adapter=cmake \
+                  --base "$REGRESSION_BASE" --head "$REGRESSION_HEAD" \
+                  --generate
+              fi
+
+              if ! jq -e ".testPresets // [] | length > 0" CMakeUserPresets.json >/dev/null; then
+                echo "No affected test suites; skipping build and test."
+                exit 0
+              fi
+
+              cmake --workflow --preset regression.debug
+              ctest --preset regression.debug -j --timeout 3000
+            '
 
   public-ci:
     name: Public CI
     if: ${{ always() && github.event_name == 'pull_request' }}
     needs:
-      - prepare
+      - plan
       - regression
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Require lint and regression
         env:
-          PREPARE_RESULT: ${{ needs.prepare.result }}
+          PLAN_RESULT: ${{ needs.plan.result }}
           REGRESSION_RESULT: ${{ needs.regression.result }}
         run: |
           set -euo pipefail
-          test "$PREPARE_RESULT" = success
+          test "$PLAN_RESULT" = success
           test "$REGRESSION_RESULT" = success

--- a/.github/workflows/formosa-regression.yml
+++ b/.github/workflows/formosa-regression.yml
@@ -32,17 +32,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up xmake
-        uses: xmake-io/github-action-setup-xmake@3a1a5dddfc7fa625d9a698738334bf55655a861a # v1.2.5
-        with:
-          xmake-version: "3.0.4"
-
-      - name: Validate generated presets
-        run: |
-          set -euo pipefail
-          test -s CMakePresets.json
-          xmake workflow check
-
       - name: Select regression range
         id: range
         env:
@@ -108,6 +97,38 @@ jobs:
             --format '{{index .RepoDigests 0}}' "$image")
           [[ "$image_ref" =~ ^ghcr\.io/formosa-gpgpu/formosa@sha256:[0-9a-f]{64}$ ]]
           echo "image=$image_ref" >>"$GITHUB_OUTPUT"
+
+      - name: Validate generated presets
+        env:
+          FORMOSA_CI_IMAGE: ${{ steps.image.outputs.image }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --env HOME=/tmp \
+            --env TMP=/tmp \
+            --env TEMP=/tmp \
+            --env TEMPDIR=/tmp \
+            --env TMPDIR=/tmp \
+            --env NIX_BUILD_TOP=/tmp \
+            --tmpfs /tmp:rw,exec,mode=1777 \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$FORMOSA_CI_IMAGE" \
+            bash -c '
+              set -eo pipefail
+              set +u
+              rc=(/nix/store/*-nix-shell-rc)
+              if (( ${#rc[@]} != 1 )); then
+                printf "expected one Nix shell rc, found %d\n" "${#rc[@]}" >&2
+                exit 1
+              fi
+              source "${rc[0]}"
+              set -euo pipefail
+
+              test -s CMakePresets.json
+              xmake workflow check
+            '
 
       - name: Lint changed files
         if: steps.range.outputs.use_all != 'true'

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -18,13 +18,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - name: Set up xmake
-        uses: xmake-io/github-action-setup-xmake@3a1a5dddfc7fa625d9a698738334bf55655a861a # v1.2.5
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
-          xmake-version: "3.0.4"
+          enable_kvm: false
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate CMake presets
         run: |
           set -euo pipefail
           test -s CMakePresets.json
-          xmake workflow check
+          nix shell --inputs-from . nixpkgs#xmake --command xmake workflow check

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -16,12 +16,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Set up xmake
+        uses: xmake-io/github-action-setup-xmake@3a1a5dddfc7fa625d9a698738334bf55655a861a # v1.2.5
+        with:
+          xmake-version: "3.0.4"
+
       - name: Validate CMake presets
         run: |
+          set -euo pipefail
           test -s CMakePresets.json
-          jq -e '
-            (.version | type == "number") and
-            (.testPresets | type == "array") and
-            ((.testPresets | length) == 17)
-          ' CMakePresets.json >/dev/null
+          xmake workflow check

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,6 +6,7 @@ on:
       - .github/scripts/push-image.sh
       - .github/workflows/formosa-regression.yml
       - .github/workflows/publish-docker.yml
+      - .github/workflows/init.yml
   push:
     branches: [main]
   workflow_dispatch:
@@ -29,7 +30,7 @@ jobs:
       image_ref: ${{ steps.image.outputs.image_ref }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -104,7 +105,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Install Nix
         uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
@@ -121,7 +122,8 @@ jobs:
               actionlint -shellcheck shellcheck \
                 -ignore "unexpected key \"queue\" for \"concurrency\"" \
                 .github/workflows/formosa-regression.yml \
-                .github/workflows/publish-docker.yml
+                .github/workflows/publish-docker.yml \
+                .github/workflows/init.yml
               shellcheck .github/scripts/push-image.sh
             '
 
@@ -149,7 +151,7 @@ jobs:
           df -h /
 
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Install Nix
         uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1


### PR DESCRIPTION
Replace the stale testPresets matrix (perf.opencl filter, 17-preset assumption) with a single impact-based regression.debug job planned by xmake workflow regression. PRs run affected suites only; main runs --all. Update actions/checkout v4.2.2 (node20) to v5.1.0 (node24) and validate generated presets with xmake workflow check instead of a hardcoded count.